### PR TITLE
Changed the Routing Path

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,18 +8,18 @@ import Contact from "./pages/Contact"
 import Layout from "./Layout/Layout";
 
 function App() {
-  return (
-    <BrowserRouter>
-      <Routes>
-          <Route path="/" element={<Layout/>}>
-              <Route index element={<Home/>}/>
-              <Route path="/events" element={<Events/>} />
-              <Route path="/team" element={<Team/>} />
-              <Route path="/contact" element={<Contact/>} />
-          </Route>
-      </Routes>
-    </BrowserRouter>
-  );
+      return (
+        <Router>
+          <Navbar />
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/events" element={<Events />} />
+            <Route path="/team" element={<Team />} />
+            <Route path="/contact" element={<Contact />} />
+          </Routes>
+          <Footer />
+        </Router>
+      );
 }
 
 export default App;


### PR DESCRIPTION
@akshit-g @rohin079 The way the routing path was given did not render any of the elements properly, made the correction so that elements are now properly render based on its route. In this corrected version, I am using the component's element prop to specify the component to render for each route. The element prop is used in React Router v6 to specify the component for a route, replacing the component prop used in v5.